### PR TITLE
improve browse and favorites grid, fix mobile menu bg issues

### DIFF
--- a/src/app/components/avatar.component.ts
+++ b/src/app/components/avatar.component.ts
@@ -28,14 +28,17 @@ import { JsonPipe } from '@angular/common';
 
     <div
       id="userDropdown"
-      class="z-10 hidden divide-y rounded-lg shadow w-44 bg-gray-800 divide-gray-600"
+      class="z-10 hidden divide-y rounded-lg shadow w-44 bg-gray-800 divide-gray-600 border-gray-700 border-[1px]"
     >
       <div class="px-4 py-3 text-sm text-white">
         <div class="font-medium truncate">
           {{ authStore.user()?.email ?? 'anonymous@whoknows.com' }}
         </div>
       </div>
-      <ul class="py-2 text-sm text-gray-200" aria-labelledby="avatarButton">
+      <ul
+        class="py-2 text-sm text-gray-200 border-gray-700"
+        aria-labelledby="avatarButton"
+      >
         <li>
           <a
             routerLink="/profile"

--- a/src/app/components/card.component.ts
+++ b/src/app/components/card.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, EventEmitter, Output, effect, input } from '@angular/core';
+import { Component, EventEmitter, Output, input } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 @Component({
@@ -9,10 +9,14 @@ import { RouterModule } from '@angular/router';
   template: `
     <a
       [routerLink]="[cardClickUrl() ? cardClickUrl() : '']"
-      class="block max-w-sm border rounded-lg shadow bg-gray-800 border-gray-700"
+      class="block border rounded-lg shadow bg-gray-800 border-gray-700"
     >
       <a>
-        <img class="rounded-t-lg" [src]="imageUrl()" [alt]="imageAlt()" />
+        <img
+          class="rounded-t-lg w-full"
+          [src]="imageUrl()"
+          [alt]="imageAlt()"
+        />
       </a>
       <div class="p-5 flex flex-col items-center">
         <a>
@@ -49,6 +53,8 @@ export class CardComponent {
   buttonText = input<string>();
   cardClickUrl = input<string | null>(null);
   @Output() buttonClick = new EventEmitter();
+
+  constructor(private router: RouterModule) {}
 
   buttonClickHandler(e: MouseEvent): void {
     e.stopPropagation();

--- a/src/app/components/navbar.component.ts
+++ b/src/app/components/navbar.component.ts
@@ -22,7 +22,7 @@ import { RouterModule } from '@angular/router';
         <button
           data-collapse-toggle="navbar-default"
           type="button"
-          class="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-500 rounded-lg md:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-600"
+          class="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-500 rounded-lg md:hidden focus:outline-none focus:ring-2 focus:ring-gray-600"
           aria-controls="navbar-default"
           aria-expanded="false"
         >
@@ -71,7 +71,7 @@ import { RouterModule } from '@angular/router';
                 <a
                   routerLink="/favorite-pokemon"
                   routerLinkActive="bg-blue-500 md:bg-transparent md:text-blue-500"
-                  class="block py-2 px-3 text-white rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0"
+                  class="block py-2 px-3 text-white rounded md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0"
                   >Favorites</a
                 >
               </li>
@@ -83,7 +83,7 @@ import { RouterModule } from '@angular/router';
                 <a
                   routerLink="/profile"
                   routerLinkActive="bg-blue-500 md:bg-transparent md:text-blue-500"
-                  class="block py-2 px-3 text-white rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0"
+                  class="block py-2 px-3 text-white rounded md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0"
                   >Profile</a
                 >
               </li>
@@ -91,7 +91,7 @@ import { RouterModule } from '@angular/router';
                 <a
                   routerLink="/login"
                   (click)="authStore.signOut()"
-                  class="block py-2 px-3 text-white rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0e"
+                  class="block py-2 px-3 text-white rounded md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0e"
                   >Sign out</a
                 >
               </li>
@@ -100,7 +100,7 @@ import { RouterModule } from '@angular/router';
                 <a
                   routerLink="/login"
                   routerLinkActive="bg-blue-500 md:bg-transparent md:text-blue-500"
-                  class="block py-2 px-3 text-white rounded hover:bg-gray-100 md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0"
+                  class="block py-2 px-3 text-white rounded md:hover:bg-transparent md:border-0 md:hover:text-white md:p-0"
                   >Sign In</a
                 >
               </li>

--- a/src/app/pages/browse-pokemon-page.component.ts
+++ b/src/app/pages/browse-pokemon-page.component.ts
@@ -11,9 +11,12 @@ import { PokemonImagePipe } from 'src/app/utils/pokemon-image.pipe';
     class: 'h-full w-full',
   },
   template: `
-    <div class="flex flex-wrap gap-4 justify-center my-4">
+    <div
+      class="grid xs:grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4 p-4"
+    >
       @for (item of pokemonStore.pokemonCollection(); track item.name) {
         <app-card
+          class="h-auto max-w-full"
           [cardClickUrl]="'/pokemon/' + item.name"
           [imageUrl]="item.url | pokemonImageUrlFromUrl"
           [imageAlt]="item.name"

--- a/src/app/pages/favorite-pokemon.component.ts
+++ b/src/app/pages/favorite-pokemon.component.ts
@@ -14,9 +14,12 @@ import { CardComponent } from '../components/card.component';
     @if (pokemonStore.favoritePokemon().length === 0) {
       <h1 class="text-4xl font-bold">No favorite Pokemon</h1>
     } @else {
-      <div class="flex flex-wrap gap-4 justify-center">
+      <div
+        class="grid xs:grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4 p-4"
+      >
         @for (pokemon of pokemonStore.favoritePokemon(); track pokemon.id) {
           <app-card
+            class="h-auto max-w-full"
             [imageUrl]="pokemon.url_to_pokemon_image"
             [cardClickUrl]="'/pokemon/' + pokemon.pokemon_name"
             [imageAlt]="pokemon.pokemon_name"

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#1976d2">
 </head>
-  <body class="bg-slate-900 text-white">
+  <body class="bg-gray-900 text-white">
     <app-root></app-root>
     <noscript>Please enable JavaScript to continue using this application.</noscript>
 </body>

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,4 +11,3 @@ body {
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
-


### PR DESCRIPTION
- Uses grid instead of flexbox to display pokemon grids on browse and favorites page
- grid has 1 column on mobile, 2 columns when they fit, 3 columns on medium, 4 columns on large, and 5 columns on extra large view port widths
- fixed a weird issue on mobile menu that only happened on my phone (not mobile view in browser dev tools) where clicking on a nav item in the mobile menu turned it gray. Same happened with the menu button. There was some leftover copypasta from flowbite for a light theme hover on there and I hadn't removed it. I think hover was causing some issues with touch on mobile